### PR TITLE
feat: add toggle to use the old naming scheme

### DIFF
--- a/custom_components/enphase_gateway/const.py
+++ b/custom_components/enphase_gateway/const.py
@@ -27,6 +27,7 @@ CONF_TOKEN_RAW = "token_raw"
 CONF_USE_TOKEN_CACHE = "use_token_cache"
 CONF_TOKEN_CACHE_FILEPATH = "token_cache_filepath"
 CONF_SINGLE_INVERTER_ENTITIES = "single_inverter_entities"
+CONF_USE_LEGACY_NAME = "use_lagacy_name"
 
 SENSORS = (
     SensorEntityDescription(

--- a/custom_components/enphase_gateway/gateway_reader/gateway_reader.py
+++ b/custom_components/enphase_gateway/gateway_reader/gateway_reader.py
@@ -36,6 +36,7 @@ ENDPOINT_URL_PRODUCTION = "{}://{}/production"
 ENDPOINT_URL_CHECK_JWT = "https://{}/auth/check_jwt"
 ENDPOINT_URL_ENSEMBLE_INVENTORY = "{}://{}/ivp/ensemble/inventory"
 ENDPOINT_URL_HOME_JSON = "{}://{}/home.json"
+ENDPOINT_URL_INFO_XML = "{}://{}/info.xml"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -561,19 +562,20 @@ class GatewayReader:
             return None
 
     async def get_serial_number(self):
-        """Get the Envoy serial number."""
-        response = await self._async_get(
-            f"http{self._protocol}://{self.host}/info.xml",
-            follow_redirects=True,
-        )
-        if not response.text:
+        """Try to fetch the serial number from /info.xml."""
+        url = ENDPOINT_URL_INFO_XML.format(self._protocol, self.host)
+        try:
+            response = await self._async_get(url, follow_redirects=True).text
+        except:
             return None
-        if "<sn>" in response.text:
-            return response.text.split("<sn>")[1].split("</sn>")[0]
-        match = SERIAL_REGEX.search(response.text)
-        if match:
-            return match.group(1)
-
+        else:
+            if "<sn>" in response:
+                return response.split("<sn>")[1].split("</sn>")[0]  
+            elif match := SERIAL_REGEX.search(response):
+                return match.group(1)
+        
+        return None
+        
     def create_connect_errormessage(self):
         """Create error message if unable to connect to Envoy."""
         return (

--- a/custom_components/enphase_gateway/test.py
+++ b/custom_components/enphase_gateway/test.py
@@ -7,7 +7,17 @@ import datetime
 
 test1 ={"teyt": 1}
 test2 ={"teyt1": 2}
+x=1
+y=2
+if x==1 and y == 3:
+    print("x")
+    
+v = True
+z= True
 
-x = "  "
-if x:
-    print("test")
+test1 = "Envoy"
+test2 = "Enphase Gateway"
+
+if "Envo" in ("Envoy",):
+    print("v")
+


### PR DESCRIPTION
- Add a toggle to config_flow to allow the user to continue using the old naming scheme.
- Refactor config_flow.py.